### PR TITLE
Added baseurl logic to handle github pages path

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ title: Dignari Digital Wallet Design System
 email: jeff.stephens@dignari.com
 description: >- # this means to ignore newlines until "baseurl:"
   Welcome to the Dignari digital wallet design system website.
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "/digital-wallet-site" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jeffdstephens
 github_username: jeff-stephens-dignari

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,8 +3,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
-  <link rel="stylesheet" href="{{ "/assets/uswds-2.9.0/css/uswds.min.css" | relative_url }}">
-  <link rel="stylesheet" href="{{ "/assets/css/styles.css" | relative_url }}">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/uswds-2.9.0/css/uswds.min.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/styles.css">
   {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
         {{ content }}
       </div>
     </main>
-    <script src="{{ "/assets/js/uswds.min.js" | relative_url }}"></script>
+    <script src="{{ site.baseurl }}/assets/js/uswds.min.js" ></script>
   </body>
 
   <!-- This section is for the footer -->


### PR DESCRIPTION
Github pages uses a path that includes the project/repo name. In order to address this, had to add the baseurl value of `/digital-wallet-site` to the `_config.yml` file. Then had to use `{{site.baseurl}}` when referring to css and js locations. 