### PR TITLE
Updated path for logo, routing, and close button on mobile menu

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,13 +10,13 @@
   <div class="usa-nav-container">
     <div class="usa-navbar">
   <div class="usa-logo" id="basic-logo">
-    <em class="usa-logo__text"><a href="/" title="Home" aria-label="Home">{{site.title}}</a></em>
+    <em class="usa-logo__text"><a href="{{site.baseurl}}/" title="Home" aria-label="Home">{{site.title}}</a></em>
   </div>
   <button class="usa-menu-btn">Menu</button>
 </div>
 
 <nav aria-label="Primary navigation" class="usa-nav">
-      <button class="usa-nav__close"><img src="/assets/img/close.svg" role="img" alt="close"></button>
+      <button class="usa-nav__close"><img src="{{site.baseurl}}/assets/img/close.svg" role="img" alt="close"></button>
 <ul class="usa-nav__primary usa-accordion"><li class="usa-nav__primary-item">  
     <a class="usa-nav__link" href="https://www.dignari.com" target="_blank"><span>visit us @ dignari.com</span></a>
 </form>
@@ -64,7 +64,7 @@
       <div class="grid-container">
         <div class="usa-footer__logo grid-row grid-gap-2">
           <div class="grid-col-auto">
-            <img class="usa-footer__logo-img" src="/assets/img/Block_Dignari_Light.png" alt="">
+            <img class="usa-footer__logo-img" src="{{site.baseurl}}/assets/img/Block_Dignari_Light.png" alt="">
           </div>
           <div class="grid-col-auto">
             <h3 class="usa-footer__logo-heading">Dignari</h3>


### PR DESCRIPTION
Needed to add `{{site.baseurl}}` when providing paths to resources such as the logo file, the routing for the header link, and the close menu icon. 